### PR TITLE
Fix Nick Janetakis' Docker feed

### DIFF
--- a/feeds.txt
+++ b/feeds.txt
@@ -20,7 +20,7 @@ http://collabnix.com/feed
 https://technologyconversations.com/category/docker/feed/
 http://blog.codeship.com/author/laurafrank/feed/
 http://blog.loof.fr/feeds/posts/default
-http://nickjanetakis.com/atom.xml
+https://diveintodocker.com/atom.xml
 https://manesh.me/tag/docker/feed/
 http://lucjuggery.com/blog/?feed=rss2&tag=docker
 http://feeds.feedburner.com/KendrickColeman?format=xml


### PR DESCRIPTION
My personal website has a lot of non-Docker related material.

I've edited my feed URL to point to my dedicated Docker blog.